### PR TITLE
scheduler-hackloop remote/local, host updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .vscode/
 index.d.ts
+foo-scratch.js

--- a/devScripts/webserver.js
+++ b/devScripts/webserver.js
@@ -106,7 +106,8 @@ export async function main(ns) {
 
     for (let i = 0; i < scripts.length; i += 1) {
         const script = scripts[i];
-        await ns.wget(\`http://localhost:8080/$\{script}\`, script, 'home');
+        const host = ns.getHostname();
+        await ns.wget(\`http://localhost:8080/$\{script}\`, script, host);
     }
 }
 `;

--- a/src/netmap.js
+++ b/src/netmap.js
@@ -6,11 +6,13 @@
  */
 const hydrateServers = (ns, data, node) => {
   const children = ns.scan(node);
+  const purchasedServers = ns.getPurchasedServers();
   children.forEach((server) => {
     const isNetTarget =
       data[server] === undefined &&
       server !== 'home' && // ignore our starter computer
-      server.indexOf('home-minion-') !== 0; // ignore auto-purchased computers
+      !purchasedServers.includes(server); // ignore all purchased servers
+      //server.indexOf('home-minion-') !== 0; // ignore auto-purchased computers
     if (isNetTarget) {
       data[server] = {
         reqHackSkill: ns.getServerRequiredHackingLevel(server),

--- a/src/prepServer.js
+++ b/src/prepServer.js
@@ -9,7 +9,9 @@ export async function main(ns) {
   try {
     const target = ns.args[0];
     const nextScript = ns.args[1];
+    const currentHost = ns.getHostname();
 
+    // we do want to run these from "home"
     if (ns.fileExists('BruteSSH.exe', 'home')) {
       ns.brutessh(target);
     }
@@ -29,7 +31,8 @@ export async function main(ns) {
     ns.nuke(target);
 
     if (nextScript) {
-      await ns.scp('hackloop-remote.js', 'home', target);
+      // copy remote script from this server to target
+      await ns.scp(nextScript, currentHost, target);
       const ramReq = ns.getScriptRam(nextScript, target);
       const availableRam =
         ns.getServerMaxRam(target) - ns.getServerUsedRam(target);

--- a/src/scheduler-hackloop.js
+++ b/src/scheduler-hackloop.js
@@ -6,6 +6,16 @@ const hackTools = [
   'SQLInject.exe',
 ];
 
+const factionServers = [
+  "CSEC",
+  "avmnite-01h",
+  "I.I.I.I",
+  "run3theh111z",
+  "The-Cave",
+  "w-1r1d_d43m0n",
+  "darkweb",
+];
+
 /**
  * @param {import(".").NS} ns Use just "@param {NS} ns" if editing in game
  */
@@ -14,17 +24,45 @@ export async function main(ns) {
    * Check available memory and purchase "home" memory in loop
    * CSEC doesn't have money. No real reason to continue the script once hacked first time
    */
-  const hackScript = 'hackloop-remote.js';
+  ns.disableLog('sleep');
+  const args = ns.flags([['help', false]]);
+  let runType = args._[0];
+
+  let shouldShowHelp = !runType ||
+    !['local', 'remote', 'both'].includes(runType) ||
+    args.help;
+
+  if (shouldShowHelp) {
+    ns.tprint('This script auto-hacks all servers based on hack skill and available cracking tools.');
+    ns.tprint(`Usage: run ${ns.getScriptName()} RUNTYPE`);
+    ns.tprint('Where RUNTYPE is one of: local remote both.')
+    ns.tprint('NOTE: When running remotely, it will use the max number');
+    ns.tprint('of threads to use as much of the targets RAM as possible.')
+    ns.tprint('');
+    ns.tprint('WARN: Running locally will (eventually) use a lot of RAM on the host.')
+    ns.tprint('Example:');
+    ns.tprint(`> run ${ns.getScriptName()} remote`);
+    ns.tprint(`> run ${ns.getScriptName()} local`);
+    ns.tprint(`> run ${ns.getScriptName()} both`);
+    return;
+  }
+
+  const hackScriptLocal = 'hackloop.js';
+  const hackScriptRemote = 'hackloop-remote.js';
+  const crackScript = 'prepServer.js';
+
   const homeHost = 'home';
+  const currentHost = ns.getHostname();
+
   const sleepTime = 1000 * 60; // milliseconds
   let running = true;
 
-  if (!ns.fileExists('netmap-data.json', 'home')) {
-    ns.exec('netmap.js', 'home', 1);
+  if (!ns.fileExists('netmap-data.json', currentHost)) {
+    ns.exec('netmap.js', currentHost, 1);
     let netmapRunning = true;
     do {
       await ns.sleep(1000);
-      netmapRunning = !ns.fileExists('netmap-data.json', 'home');
+      netmapRunning = !ns.fileExists('netmap-data.json', currentHost);
     } while (netmapRunning)
   }
 
@@ -49,35 +87,59 @@ export async function main(ns) {
       if (!meta) {
         ns.print(`WARNING: Could not find metadata for server: ${target}`);
       } else {
+        // add faction script to meta for faction servers
+        if (factionServers.includes(target)) {
+          meta.runScript = 'backdoor.js';
+        }
         // Check if a script is running
-        const isRunning = ns.isRunning(hackScript, target);
+        const isRunningLocal = ns.isRunning(hackScriptLocal, currentHost, target); // run hackloop.js target
+        const isRunningRemote = ns.isRunning(hackScriptRemote, target); // remote exec, see below
 
         // Check if the server is hacked and we could hack it
         const hackSkillMet = hackingSkill >= meta.reqHackSkill;
         const toolCountMet = hackToolCount >= meta.reqNukePorts;
         const alreadyHacked = ns.hasRootAccess(target);
+
         const shouldRun =
           hackSkillMet &&
           toolCountMet &&
-          !isRunning &&
           (meta.restartHack || !alreadyHacked);
+        const shouldRunLocal =
+          shouldRun &&
+          !isRunningLocal &&
+          (runType === 'local' || runType === 'both');
+        const shouldRunRemote =
+          shouldRun &&
+          !isRunningRemote &&
+          (runType === 'remote' || runType === 'both');
 
-        if (shouldRun) {
-          ns.print(`Starting hack on ${target}`);
-          // ns.exec(meta.runScript || 'hackloop.js', 'home', 1, target);
+        if (shouldRunLocal) {
+          ns.toast(`Starting hack locally against ${target}`);
+          ns.print(`Starting hack locally against ${target}`);
+          ns.exec(meta.runScript || hackScriptLocal, currentHost, 1, target);
+        }
+        if (shouldRunRemote) {
+          ns.toast(`Starting hack remotely on ${target}`);
           const remotePid = ns.exec(
-            'prepServer.js',
-            'home',
+            crackScript,
+            currentHost,
             1,
             target,
-            'hackloop-remote.js',
+            hackScriptRemote,
           );
-          ns.print(`Spawning on remote ${target} pid ${remotePid}`);
-          await ns.sleep(1000);
+          if (remotePid === 0) {
+            ns.toast(`FAILED to run crackScript ${crackScript} on remote ${target}`);
+            ns.print(`FAILED to run crackScript ${crackScript} on remote ${target}`);
+          } else {
+            ns.toast(`Spawning on remote ${target} pid ${remotePid}`);
+            ns.print(`Spawning on remote ${target} pid ${remotePid}`);
+          }
         }
+        await ns.sleep(500); // sleep 0.5 second to give time for next server on this pass
       }
     }
 
     await ns.sleep(sleepTime);
+    ns.print(`Snoozing for ${sleepTime/1000} seconds.`)
   } while (running);
 }

--- a/src/sync-scripts-wrapper.js
+++ b/src/sync-scripts-wrapper.js
@@ -5,10 +5,11 @@
  * @param {import(".").NS} ns Use just "@param {NS} ns" if editing in game
  */
 export async function main(ns) {
+  const host = ns.getHostname();
   await ns.wget(
     'http://localhost:8080/sync-scripts.js',
     'sync-scripts.js',
-    'home',
+    host,
   );
-  ns.exec('sync-scripts.js', 'home', 1);
+  ns.exec('sync-scripts.js', host, 1);
 }

--- a/src/tempest-connect.js
+++ b/src/tempest-connect.js
@@ -1,0 +1,36 @@
+/* shamelessly stolen from u/Tempest_42 
+ * https://www.reddit.com/r/Bitburner/comments/rhpp8p/scan_script_updated_for_bitburner_v110/
+ */
+/**
+ * @param {import(".").NS} ns Use just "@param {NS} ns" if editing in game
+ */
+export async function main(ns) {
+    let target = ns.args[0];
+    let paths = { "home": "" };
+    let queue = Object.keys(paths);
+    let name;
+    let output;
+    let pathToTarget;
+    while ((name = queue.shift())) {
+        let path = paths[name];
+        let scanRes = ns.scan(name);
+        for (let newSv of scanRes) {
+            if (paths[newSv] === undefined) {
+                queue.push(newSv);
+                paths[newSv] = `${path},${newSv}`;
+                if (newSv == target)
+                    pathToTarget = paths[newSv].substr(1).split(",");
+                    
+            }
+        }
+    }
+    output = "home; ";
+
+    pathToTarget.forEach(server=> output += " connect " + server + ";");
+
+    const terminalInput = document.getElementById("terminal-input");
+    terminalInput.value=output;
+    const handler = Object.keys(terminalInput)[1];
+    terminalInput[handler].onChange({target:terminalInput});
+    terminalInput[handler].onKeyDown({keyCode:13,preventDefault:()=>null});
+}

--- a/src/tempest-scan.js
+++ b/src/tempest-scan.js
@@ -1,0 +1,81 @@
+/* shamelessly stolen from u/Tempest_42 
+ * https://www.reddit.com/r/Bitburner/comments/rhpp8p/scan_script_updated_for_bitburner_v110/
+ */
+/**
+ * @param {import(".").NS} ns Use just "@param {NS} ns" if editing in game
+ */
+let factionServers = {
+    "CSEC" : "yellow",
+    "avmnite-02h" : "yellow",
+    "I.I.I.I" : "yellow",
+    "run4theh111z" : "yellow",
+    "The-Cave" : "orange",
+    "w0r1d_d43m0n" : "red"
+};
+
+let serverObj = (name = 'home', depth = 0) => ({ name: name, depth: depth });
+export function getServers(ns) {
+    let result = [];
+    let visited = { 'home': 0 };
+    let queue = Object.keys(visited);
+    let name;
+    while ((name = queue.pop())) {
+        let depth = visited[name];
+        result.push(serverObj(name, depth));
+        let scanResult = ns.scan(name);
+        for (let i = scanResult.length; i >= 0; i--) {
+            if (visited[scanResult[i]] === undefined) {
+                queue.push(scanResult[i]);
+                visited[scanResult[i]] = depth + 1;
+            }
+        }
+    }
+    return result;
+}
+
+export async function main(ns) {
+    let output = "Network:";
+
+    getServers(ns).forEach(server => {
+        let name = server.name;
+        let hackColor = ns.hasRootAccess(name) ? "lime" : "red";
+        let nameColor = factionServers[name] ? factionServers[name] : "white";
+        
+        let hoverText = ["Req Level: ", ns.getServerRequiredHackingLevel(name),
+            "&#10;Req Ports: ", ns.getServerNumPortsRequired(name),
+            "&#10;Memory: ", ns.getServerRam(name)[0], "GB",
+            "&#10;Security: ", ns.getServerSecurityLevel(name),
+            "/", ns.getServerMinSecurityLevel(name),
+            "&#10;Money: ", Math.round(ns.getServerMoneyAvailable(name)).toLocaleString(), " (", 
+            Math.round(100 * ns.getServerMoneyAvailable(name)/ns.getServerMaxMoney(name)), "%)"
+            ].join("");
+        
+        let ctText = "";
+        ns.ls(name, ".cct").forEach(ctName => {
+            ctText += ["<a title='", ctName,
+                //Comment out the next line to reduce footprint by 5 GB
+                "&#10;", ns.codingcontract.getContractType(ctName, name),
+                "'>©</a>"].join(""); 
+        });
+               
+        output += ["<br>", "---".repeat(server.depth),
+            `<font color=${hackColor}>■ </font>`,
+            `<a class='scan-analyze-link' title='${hoverText}''
+
+            onClick="(function()
+            {
+                const terminalInput = document.getElementById('terminal-input');
+                terminalInput.value='home; run tempest-connect.js ${name}';
+                const handler = Object.keys(terminalInput)[1];
+                terminalInput[handler].onChange({target:terminalInput});
+                terminalInput[handler].onKeyDown({keyCode:13,preventDefault:()=>null});
+            })();"
+        
+            style='color:${nameColor}'>${name}</a> `,
+            `<font color='fuchisa'>${ctText}</font>`,
+            ].join("");
+    });
+
+    const list = document.getElementById("terminal");
+    list.insertAdjacentHTML('beforeend',output);
+}


### PR DESCRIPTION
updated hackloop to get all servers, small tweaks

* scheduler-hackloop updated with remote, local, both options
* webserver/sync-scripts-wrapper use getHostname instead if 'home'
* prepServer uses getHostname instead of 'home'
* sync-scripts-wrapper uses getHostname instead of 'home'
* netmap takes purchased servers into account when creating map (ignores them)
* added tempest scan and connect scripts